### PR TITLE
Support table aliases in select joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,17 @@ You can perform join Query  like:
                  .in(1, 2, 3, 4)
                  .execute();
  ```
+You can also alias your selection and joined tables to work with readable column qualifiers.
+
+```java
+List<Bookmark> bookmarks = sql.select(Bookmark.class)
+        .as("my_bookmark")
+        .leftJoin(BookmarkEntry.class)
+        .as("my_bookmark_entry")
+        .on(BookmarkEntry.class, "bookmark_id").equalTo(Bookmark.class, "id")
+        .execute();
+```
+
 # Make an asynchronous SQL clause execution.
 To perform async SQL clause execution, you just need to use executeAsync instead of execute.
 ```java

--- a/src/istat/android/data/access/sqlite/SQLiteClause.java
+++ b/src/istat/android/data/access/sqlite/SQLiteClause.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -28,6 +29,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
     protected String limit = null;
     protected String[] columns;
     protected String table;
+    protected Map<String, String> tableAliases = new HashMap<String, String>();
     final static int TYPE_CLAUSE_WHERE = 0,
             TYPE_CLAUSE_AND = 1,
             TYPE_CLAUSE_OR = 2,
@@ -155,19 +157,64 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         return (Clause) this;
     }
 
-    protected static String buildRealColumnName(String tableName, String column) {
-        if (column.matches(".*\\..*")) {
+    protected void registerAlias(String tableName, String alias) {
+        if (TextUtils.isEmpty(tableName) || TextUtils.isEmpty(alias)) {
+            return;
+        }
+        tableAliases.put(tableName, alias);
+    }
+
+    protected String resolveTableName(String tableName) {
+        if (TextUtils.isEmpty(tableName)) {
+            return tableName;
+        }
+        String alias = tableAliases.get(tableName);
+        return TextUtils.isEmpty(alias) ? tableName : alias;
+    }
+
+    protected String buildRealColumnName(String tableName, String column) {
+        if (TextUtils.isEmpty(column)) {
             return column;
         }
+        Matcher qualifiedMatcher = Pattern.compile("(\\b)(\\w+)(\\.)").matcher(column);
+        StringBuffer buffer = new StringBuffer();
+        boolean hasQualifiedColumn = false;
+        while (qualifiedMatcher.find()) {
+            hasQualifiedColumn = true;
+            String physicalTable = qualifiedMatcher.group(2);
+            String resolvedTable = resolveTableName(physicalTable);
+            qualifiedMatcher.appendReplacement(buffer,
+                    qualifiedMatcher.group(1) + Matcher.quoteReplacement(resolvedTable) + qualifiedMatcher.group(3));
+        }
+        if (hasQualifiedColumn) {
+            qualifiedMatcher.appendTail(buffer);
+            return buffer.toString();
+        }
+        String resolvedTable = resolveTableName(tableName);
         Pattern pattern = Pattern.compile("(\\()(\\w*)(\\))");
         Matcher matcher = pattern.matcher(column);
+        StringBuffer columnBuffer = new StringBuffer();
+        boolean hasParenthesis = false;
         while (matcher.find()) {
             String columnNameOnly = matcher.group(2);
             if (!TextUtils.isEmpty(columnNameOnly)) {
-                column = column.replace(columnNameOnly, tableName + "." + columnNameOnly);
+                hasParenthesis = true;
+                matcher.appendReplacement(columnBuffer, matcher.group(1)
+                        + Matcher.quoteReplacement(resolvedTable) + "." + Matcher.quoteReplacement(columnNameOnly)
+                        + matcher.group(3));
             }
         }
-        return column;
+        if (hasParenthesis) {
+            matcher.appendTail(columnBuffer);
+            return columnBuffer.toString();
+        }
+        if (column.contains("(") || column.contains(")") || !column.matches("\\w+")) {
+            return column;
+        }
+        if (TextUtils.isEmpty(resolvedTable)) {
+            return column;
+        }
+        return resolvedTable + "." + column;
     }
 
     protected String buildRealColumnName(String column) {

--- a/src/istat/android/data/access/sqlite/SQLiteSelect.java
+++ b/src/istat/android/data/access/sqlite/SQLiteSelect.java
@@ -12,6 +12,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import istat.android.data.access.sqlite.interfaces.QueryAble;
 import istat.android.data.access.sqlite.interfaces.SelectionExecutable;
@@ -30,6 +32,26 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         super(clazz[0], db);
         this.clazz = clazz[0];
         this.selectionTable = this.table;
+    }
+
+    public SQLiteSelect as(String alias) {
+        if (TextUtils.isEmpty(alias) || TextUtils.isEmpty(this.table)) {
+            return this;
+        }
+        registerAlias(this.table, alias);
+        applyAliasToSelectionTable(this.table, alias);
+        return this;
+    }
+
+    private void applyAliasToSelectionTable(String tableName, String alias) {
+        if (TextUtils.isEmpty(selectionTable)) {
+            return;
+        }
+        Pattern tablePattern = Pattern.compile("^" + Pattern.quote(tableName) + "(?:\\s+AS\\s+\\S+)?");
+        Matcher matcher = tablePattern.matcher(selectionTable);
+        if (matcher.find()) {
+            selectionTable = matcher.replaceFirst(Matcher.quoteReplacement(tableName + " AS " + alias));
+        }
     }
 
     public SQLiteJoinSelect joinOn(Class<?> clazz, String on) {
@@ -546,10 +568,12 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
     public class ClauseJoinBuilder {
         SQLiteJoinSelect joinSelect;
         Class<?> clazz;
+        String joinTableName;
 
-        ClauseJoinBuilder(Class<?> clazz, SQLiteJoinSelect selection) {
+        ClauseJoinBuilder(Class<?> clazz, SQLiteJoinSelect selection, String joinTableName) {
             this.clazz = clazz;
             this.joinSelect = selection;
+            this.joinTableName = joinTableName;
         }
 
         public SQLiteJoinSelect where1() {
@@ -559,11 +583,39 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         public ClauseSubJoinBuilder on(Class<?> clazz, String name) {
             try {
                 SQLiteModel model = SQLiteModel.fromClass(clazz);
-                name = buildRealColumnName(model.getName(), name);
+                name = SQLiteSelect.this.buildRealColumnName(model.getName(), name);
             } catch (Exception e) {
                 e.printStackTrace();
             }
             return new ClauseSubJoinBuilder(joinSelect, name);
+        }
+
+        public ClauseJoinBuilder as(String alias) {
+            if (TextUtils.isEmpty(alias) || TextUtils.isEmpty(joinTableName)) {
+                return this;
+            }
+            SQLiteSelect.this.registerAlias(joinTableName, alias);
+            String joinSegment = " JOIN " + joinTableName;
+            int segmentIndex = selectionTable.lastIndexOf(joinSegment);
+            if (segmentIndex >= 0) {
+                int aliasInsertPosition = segmentIndex + joinSegment.length();
+                if (selectionTable.regionMatches(aliasInsertPosition, " AS ", 0, 4)) {
+                    int aliasStart = aliasInsertPosition + 4;
+                    int aliasEnd = selectionTable.indexOf(' ', aliasStart);
+                    if (aliasEnd < 0) {
+                        aliasEnd = selectionTable.length();
+                    }
+                    selectionTable = selectionTable.substring(0, aliasInsertPosition) + " AS " + alias
+                            + selectionTable.substring(aliasEnd);
+                } else {
+                    selectionTable = selectionTable.substring(0, aliasInsertPosition) + " AS " + alias
+                            + selectionTable.substring(aliasInsertPosition);
+                }
+            } else {
+                selectionTable += " AS " + alias;
+            }
+            this.joinSelect.selectionTable = selectionTable;
+            return this;
         }
 
         private SQLiteJoinSelect buildSubJoin() throws IllegalAccessException, InstantiationException {
@@ -594,9 +646,9 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
             try {
                 SQLiteModel model = SQLiteModel.fromClass(clazz);
                 if (whereClause == null)
-                    whereClause = new StringBuilder(buildRealColumnName(model.getName(), column));
+                    whereClause = new StringBuilder(SQLiteSelect.this.buildRealColumnName(model.getName(), column));
                 else
-                    whereClause.append(" AND " + buildRealColumnName(model.getName(), column));
+                    whereClause.append(" AND " + SQLiteSelect.this.buildRealColumnName(model.getName(), column));
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -661,7 +713,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         public SQLiteJoinSelect equalTo(Class<?> clazz, String name) {
             try {
                 SQLiteModel model = SQLiteModel.fromClass(clazz);
-                name = buildRealColumnName(model.getName(), name);
+                name = SQLiteSelect.this.buildRealColumnName(model.getName(), name);
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -679,6 +731,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
             this.whereParams = SQLiteSelect.this.whereParams;
             this.selectionTable = SQLiteSelect.this.selectionTable;
             this.table = SQLiteSelect.this.table;
+            this.tableAliases = SQLiteSelect.this.tableAliases;
         }
 
         public ClauseJoinSelectBuilder where(Class<?> clazz, String column) {
@@ -874,19 +927,16 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
     }
 
     public ClauseJoinBuilder join(Class<?> clazz, String joinType) {
-        String join;
+        String join = null;
         try {
             QueryAble entity = createQueryAble(clazz);
             join = entity.getName();
             selectionTable += joinType + " JOIN " + join;
-//            if (!TextUtils.isEmpty(on)) {
-//                selectionTable += " ON (" + on + ") ";
-//            }
         } catch (Exception e) {
             e.printStackTrace();
         }
         SQLiteJoinSelect joinSelection = new SQLiteJoinSelect(this.sql, this.clazz);
-        return new ClauseJoinBuilder(clazz, joinSelection);
+        return new ClauseJoinBuilder(clazz, joinSelection, join);
     }
 
     public SelectionExecutable limit(int limit) {


### PR DESCRIPTION
## Summary
- track table aliases in `SQLiteClause` and ensure qualified column names use the registered alias instead of physical table names
- expose `as(...)` helpers on `SQLiteSelect` and join builders so joins can register aliases while sharing the parent alias map
- document alias usage with a join example in the README

## Testing
- `./gradlew test` *(fails: Could not determine java version from '21.0.2')*

------
https://chatgpt.com/codex/tasks/task_e_68d2b1ca45248328adbf587df68d4f61