### PR TITLE
Support distinct select statements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ apply from: 'release-jar.gradle'
 dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
     api 'com.google.code.gson:gson:2.3.1'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 android {

--- a/src/istat/android/data/access/sqlite/SQLiteSelect.java
+++ b/src/istat/android/data/access/sqlite/SQLiteSelect.java
@@ -311,7 +311,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
                 columns += ",";
             }
         }
-        String out = "SELECT " + columns + " FROM " + selectionTable;
+        String out = buildSelectClause(columns);
         String whereClause = getWhereClause();
         String having = getHaving();
         String orderBy = getOrderBy();
@@ -361,7 +361,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         } catch (Exception e) {
             e.printStackTrace();
         }
-        String out = "SELECT " + columnParam + " FROM " + selectionTable;
+        String out = buildSelectClause(columnParam);
         String whereClause = getWhereClause();
         String having = getHaving();
         String orderBy = getOrderBy();
@@ -384,6 +384,11 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
             sql += " LIMIT " + limit;
         }
         return sql;
+    }
+
+    private String buildSelectClause(String columnExpression) {
+        String distinctKeyword = distinct ? "DISTINCT " : "";
+        return "SELECT " + distinctKeyword + columnExpression + " FROM " + selectionTable;
     }
 
     public class ClauseJoinSelectBuilder {

--- a/src/test/java/istat/android/data/access/sqlite/SQLiteSelectTest.java
+++ b/src/test/java/istat/android/data/access/sqlite/SQLiteSelectTest.java
@@ -1,0 +1,26 @@
+package istat.android.data.access.sqlite;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class SQLiteSelectTest {
+
+    @SQLiteModel.Table(name = "dummy_table")
+    private static class DummyEntity {
+        @SQLiteModel.PrimaryKey
+        long id;
+        String name;
+    }
+
+    @Test
+    public void getStatementShouldIncludeDistinctWhenEnabled() {
+        SQLite.SQL sql = new SQLite.SQL(null);
+        SQLiteSelect select = sql.select(true, DummyEntity.class);
+
+        String statement = select.getStatement();
+
+        assertTrue(statement.startsWith("SELECT DISTINCT "));
+        assertTrue(select.toString().startsWith("SELECT DISTINCT "));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `SQLiteSelect` prepends `DISTINCT` when requested and centralize the clause generation
- add a JVM unit test covering the distinct select statement output
- add JUnit 4 as a test dependency for the new test

## Testing
- `JAVA_HOME=/root/.local/share/mise/installs/java/17 ./gradlew test` *(fails: Gradle 2.14.1 cannot determine the Java version 17.0.2)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c45107a48328a4733da6a2936268