### PR TITLE
Fix automatic join primary key resolution

### DIFF
--- a/src/istat/android/data/access/sqlite/SQLiteSelect.java
+++ b/src/istat/android/data/access/sqlite/SQLiteSelect.java
@@ -626,9 +626,19 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
             Class<?> selectionClass = joinSelect.clazz;
             Class<?> joinClass = this.clazz;
             SQLiteModel selectionModel = SQLiteModel.fromClass(selectionClass);
-            SQLiteModel joinModel = SQLiteModel.fromClass(selectionClass);
+            SQLiteModel joinModel = SQLiteModel.fromClass(joinClass);
             Field[] fields = selectionModel.getNestedTableFields();
             String nestedPrimaryKey = joinModel.getPrimaryKeyName();
+            Field[] joinFields = joinModel.getNestedTableFields();
+            for (Field field : joinFields) {
+                if (field.getType().isAssignableFrom(selectionClass)) {
+                    String mappedPrimaryKey = SQLiteModel.getFieldNestedMappingName(field);
+                    if (!TextUtils.isEmpty(mappedPrimaryKey)) {
+                        nestedPrimaryKey = mappedPrimaryKey;
+                        break;
+                    }
+                }
+            }
             String foreignKey = selectionModel.getPrimaryKeyName();
             for (Field field : fields) {
                 if (field.getType().isAssignableFrom(joinClass)) {

--- a/src/test/java/istat/android/data/access/sqlite/SQLiteSelectTest.java
+++ b/src/test/java/istat/android/data/access/sqlite/SQLiteSelectTest.java
@@ -13,6 +13,21 @@ public class SQLiteSelectTest {
         String name;
     }
 
+    @SQLiteModel.Table(name = "parent_table")
+    private static class ParentEntity {
+        @SQLiteModel.PrimaryKey
+        long id;
+    }
+
+    @SQLiteModel.Table(name = "child_table")
+    private static class ChildEntity {
+        @SQLiteModel.PrimaryKey
+        long id;
+
+        @SQLiteModel.ManyToOne(mappedBy = "parent_id")
+        ParentEntity parent;
+    }
+
     @Test
     public void getStatementShouldIncludeDistinctWhenEnabled() {
         SQLite.SQL sql = new SQLite.SQL(null);
@@ -22,5 +37,20 @@ public class SQLiteSelectTest {
 
         assertTrue(statement.startsWith("SELECT DISTINCT "));
         assertTrue(select.toString().startsWith("SELECT DISTINCT "));
+    }
+
+    @Test
+    public void autoJoinShouldUseColumnsFromBothTables() {
+        SQLite.SQL sql = new SQLite.SQL(null);
+
+        SQLiteSelect leftJoin = sql.select(ChildEntity.class);
+        leftJoin.leftJoin(ParentEntity.class);
+        String leftStatement = leftJoin.getStatement();
+        assertTrue(leftStatement.contains("ON (child_table.parent_id=parent_table.id)"));
+
+        SQLiteSelect innerJoin = sql.select(ChildEntity.class);
+        innerJoin.innerJoin(ParentEntity.class);
+        String innerStatement = innerJoin.getStatement();
+        assertTrue(innerStatement.contains("ON (child_table.parent_id=parent_table.id)"));
     }
 }


### PR DESCRIPTION
## Summary
- ensure automatic joins use the joined class metadata to resolve the correct primary key column
- cover automatic join behaviour with a unit test that validates the ON clause references both tables

## Testing
- ./gradlew test *(fails: Could not determine java version from '21.0.2'.)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c97be9cc83289dc2d01a5817e844