### PR TITLE
Add insert-select builder with async support and instrumentation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ It is also possible to specify if you want to use an auto closable connection. (
     //SQL instance has been auto closed after execution.
 ```
 
-# Make SQL Insert 
+# Make SQL Insert
 After SQL instance has been prepared successfully, you can use it to perform SQL Insert.
 ```java
        User user = new User();
@@ -171,9 +171,24 @@ It is also possible to perform multiple insertions in one step
         System.out.println("user0 id= "+insertIds[0]);
         System.out.println("user1 id= "+insertIds[1]);
         System.out.println("user2 id= "+insertIds[2]);
-  ``` 
-  
-# Make SQL Delete 
+  ```
+
+## Insert From A Selection
+You can also duplicate rows using a `SELECT` statement while overriding columns on the fly. The next example copies the user name
+while generating a random hexadecimal identifier thanks to SQLite's `hex(randomblob(16))` helper. `ArchivedUser` is a mapped
+table that mirrors `User` and contains an extra `uuid` column.
+
+```java
+       SQLiteSelect copy = sql.select(new String[]{"userName"}, User.class)
+                              .where("userName")
+                              .equalTo("Toukea");
+
+       int inserted = sql.insertSelection(ArchivedUser.class, copy)
+                        .setExpression("uuid", "hex(randomblob(16))")
+                        .execute();
+```
+
+# Make SQL Delete
  After SQL instance has been prepared successfully, you can use it to perform SQL delete.
  ```java
          int deletedCount = sql.delete(User.class)

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,9 @@ dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
     api 'com.google.code.gson:gson:2.3.1'
     testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test:core:1.5.0'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
 }
 
 android {
@@ -16,6 +19,7 @@ android {
     defaultConfig {
         minSdkVersion 26
         targetSdkVersion 34
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     compileSdkVersion 34
 

--- a/src/androidTest/java/istat/android/data/access/sqlite/SQLiteInsertSelectionTest.java
+++ b/src/androidTest/java/istat/android/data/access/sqlite/SQLiteInsertSelectionTest.java
@@ -1,0 +1,71 @@
+package istat.android.data.access.sqlite;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(AndroidJUnit4.class)
+public class SQLiteInsertSelectionTest {
+    private SQLiteDatabase database;
+    private SQLite.SQL sql;
+
+    @Before
+    public void setUp() {
+        database = SQLiteDatabase.create(null);
+        sql = SQLite.from(database);
+        database.execSQL("CREATE TABLE source_items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+        database.execSQL("CREATE TABLE target_items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, uuid TEXT)");
+        database.execSQL("INSERT INTO source_items (name) VALUES ('alpha'), ('beta')");
+    }
+
+    @After
+    public void tearDown() {
+        database.close();
+    }
+
+    @SQLiteModel.Table(name = "source_items")
+    public static class SourceItem {
+        @SQLiteModel.PrimaryKey
+        long id;
+        String name;
+    }
+
+    @SQLiteModel.Table(name = "target_items")
+    public static class TargetItem {
+        @SQLiteModel.PrimaryKey
+        long id;
+        String name;
+        String uuid;
+    }
+
+    @Test
+    public void insertSelectionCopiesRowWithGeneratedUuid() {
+        SQLiteSelect selection = sql.select(new String[]{"name"}, SourceItem.class)
+                .where("name")
+                .equalTo("alpha");
+
+        SQLiteInsertSelection insertSelection = sql.insertSelection(TargetItem.class, selection)
+                .setExpression("uuid", "hex(randomblob(16))");
+
+        int inserted = insertSelection.execute();
+        assertEquals(1, inserted);
+
+        Cursor cursor = database.rawQuery("SELECT name, uuid FROM target_items", null);
+        assertEquals(1, cursor.getCount());
+        cursor.moveToFirst();
+        assertEquals("alpha", cursor.getString(0));
+        String uuid = cursor.getString(1);
+        assertNotNull(uuid);
+        assertEquals(32, uuid.length());
+        cursor.close();
+    }
+}

--- a/src/istat/android/data/access/sqlite/SQLite.java
+++ b/src/istat/android/data/access/sqlite/SQLite.java
@@ -719,6 +719,10 @@ public final class SQLite {
             return insert.insert(entity);
         }
 
+        public SQLiteInsertSelection insertSelection(Class<?> tableClass, SQLiteSelect selection) {
+            return new SQLiteInsertSelection(tableClass, this, selection);
+        }
+
         public SQLitePersist persist(Object entity) {
             SQLitePersist persist = new SQLitePersist(this);
             return persist.persist(entity);

--- a/src/istat/android/data/access/sqlite/SQLiteInsertSelection.java
+++ b/src/istat/android/data/access/sqlite/SQLiteInsertSelection.java
@@ -1,0 +1,232 @@
+package istat.android.data.access.sqlite;
+
+import android.database.DatabaseUtils;
+import android.database.sqlite.SQLiteDatabase;
+import android.text.TextUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import istat.android.data.access.sqlite.utils.SQLiteAsyncExecutor;
+import istat.android.data.access.sqlite.utils.SQLiteThread;
+
+public final class SQLiteInsertSelection extends SQLiteClause<SQLiteInsertSelection> {
+    private final SQLiteModel targetModel;
+    private final LinkedHashMap<String, Projection> projections = new LinkedHashMap<String, Projection>();
+    private final String sourceTable;
+    private final boolean sourceDistinct;
+
+    SQLiteInsertSelection(Class<?> tableClass, SQLite.SQL sql, SQLiteSelect selection) {
+        super(tableClass, sql);
+        try {
+            this.targetModel = SQLiteModel.fromClass(tableClass);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to resolve model for " + tableClass, e);
+        }
+        this.sourceTable = selection.selectionTable;
+        this.sourceDistinct = selection.distinct;
+        copySelectionState(selection);
+    }
+
+    private void copySelectionState(SQLiteSelect selection) {
+        if (selection.columns != null) {
+            this.columns = selection.columns.clone();
+        } else {
+            this.columns = new String[0];
+        }
+        this.whereClause = selection.whereClause != null ? new StringBuilder(selection.whereClause.toString()) : null;
+        this.whereParams = new ArrayList<String>(selection.whereParams);
+        this.having = selection.having != null ? new StringBuilder(selection.having.toString()) : null;
+        this.havingWhereParams = new ArrayList<String>(selection.havingWhereParams);
+        this.orderBy = selection.orderBy;
+        this.groupBy = selection.groupBy;
+        this.limit = selection.limit;
+        this.tableAliases.putAll(selection.tableAliases);
+        for (String column : this.columns) {
+            projections.put(column, new Projection(column, column));
+        }
+    }
+
+    public SQLiteInsertSelection set(String column, Object value) {
+        Projection projection = ensureProjection(column);
+        projection.expression = "?";
+        projection.bindArg = value;
+        updateColumns();
+        return this;
+    }
+
+    public SQLiteInsertSelection setAs(Object entity) {
+        if (entity == null) {
+            return this;
+        }
+        try {
+            SQLiteModel model = SQLiteModel.fromObject(entity,
+                    sql.getSerializer(entity.getClass()),
+                    sql.getContentValueHandler(entity.getClass()));
+            for (Map.Entry<String, Object> entry : model.toHashMap().entrySet()) {
+                if (targetModel.hasColumn(entry.getKey())) {
+                    set(entry.getKey(), entry.getValue());
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return this;
+    }
+
+    public SQLiteInsertSelection setExpression(String column, String rawSql) {
+        Projection projection = ensureProjection(column);
+        projection.expression = rawSql;
+        projection.bindArg = null;
+        updateColumns();
+        return this;
+    }
+
+    private Projection ensureProjection(String column) {
+        Projection projection = projections.get(column);
+        if (projection == null) {
+            projection = new Projection(column, column);
+            projections.put(column, projection);
+        }
+        return projection;
+    }
+
+    private void updateColumns() {
+        this.columns = projections.keySet().toArray(new String[0]);
+    }
+
+    @Override
+    protected Object onExecute(SQLiteDatabase db) {
+        notifyExecuting();
+        String sqlStatement = buildInsertSelectSql();
+        Object[] bindArgs = buildBindArgsArray();
+        if (bindArgs.length > 0) {
+            db.execSQL(sqlStatement, bindArgs);
+        } else {
+            db.execSQL(sqlStatement);
+        }
+        long changes = DatabaseUtils.longForQuery(db, "SELECT changes()", null);
+        return (int) changes;
+    }
+
+    public int execute() {
+        try {
+            return (Integer) onExecute(sql.db);
+        } finally {
+            notifyExecuted();
+        }
+    }
+
+    public SQLiteThread<Integer> executeAsync() {
+        return executeAsync(null);
+    }
+
+    public SQLiteThread<Integer> executeAsync(final SQLiteAsyncExecutor.ExecutionCallback<Integer> callback) {
+        SQLiteAsyncExecutor executor = new SQLiteAsyncExecutor();
+        return executor.execute(this, callback);
+    }
+
+    @Override
+    public String getStatement() {
+        String sqlStatement = buildInsertSelectSql();
+        List<String> bindArgs = new ArrayList<String>();
+        for (Object arg : buildBindArgs()) {
+            bindArgs.add(arg == null ? "null" : String.valueOf(arg));
+        }
+        return compute(sqlStatement, bindArgs);
+    }
+
+    @Override
+    protected void notifyExecuting() {
+        super.notifyExecuting();
+    }
+
+    private String buildInsertSelectSql() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("INSERT INTO ");
+        builder.append(targetModel.getName());
+        if (!projections.isEmpty()) {
+            builder.append(" (");
+            int index = 0;
+            for (Projection projection : projections.values()) {
+                builder.append(projection.column);
+                if (index < projections.size() - 1) {
+                    builder.append(", ");
+                }
+                index++;
+            }
+            builder.append(") ");
+        }
+        builder.append(buildSelectClause());
+        return builder.toString();
+    }
+
+    private String buildSelectClause() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("SELECT ");
+        if (sourceDistinct) {
+            builder.append("DISTINCT ");
+        }
+        int index = 0;
+        for (Projection projection : projections.values()) {
+            builder.append(projection.expression);
+            if (index < projections.size() - 1) {
+                builder.append(", ");
+            }
+            index++;
+        }
+        builder.append(" FROM ");
+        builder.append(sourceTable);
+        if (whereClause != null && whereClause.length() > 0) {
+            builder.append(" WHERE ");
+            builder.append(whereClause.toString().trim());
+        }
+        if (!TextUtils.isEmpty(groupBy)) {
+            builder.append(" GROUP BY ");
+            builder.append(groupBy);
+        }
+        if (having != null && having.length() > 0) {
+            builder.append(" HAVING ");
+            builder.append(having.toString().trim());
+        }
+        if (!TextUtils.isEmpty(orderBy)) {
+            builder.append(" ORDER BY ");
+            builder.append(orderBy);
+        }
+        if (!TextUtils.isEmpty(limit)) {
+            builder.append(" LIMIT ");
+            builder.append(limit);
+        }
+        return builder.toString();
+    }
+
+    private List<Object> buildBindArgs() {
+        List<Object> args = new ArrayList<Object>();
+        for (Projection projection : projections.values()) {
+            if ("?".equals(projection.expression)) {
+                args.add(projection.bindArg);
+            }
+        }
+        args.addAll(whereParams);
+        args.addAll(havingWhereParams);
+        return args;
+    }
+
+    private Object[] buildBindArgsArray() {
+        List<Object> args = buildBindArgs();
+        return args.toArray(new Object[args.size()]);
+    }
+
+    private static class Projection {
+        final String column;
+        String expression;
+        Object bindArg;
+
+        Projection(String column, String expression) {
+            this.column = column;
+            this.expression = expression;
+        }
+    }
+}

--- a/src/istat/android/data/access/sqlite/utils/SQLiteAsyncExecutor.java
+++ b/src/istat/android/data/access/sqlite/utils/SQLiteAsyncExecutor.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import istat.android.data.access.sqlite.SQLiteDelete;
 import istat.android.data.access.sqlite.SQLiteInsert;
+import istat.android.data.access.sqlite.SQLiteInsertSelection;
 import istat.android.data.access.sqlite.SQLiteMerge;
 import istat.android.data.access.sqlite.SQLitePersist;
 import istat.android.data.access.sqlite.SQLiteSelect;
@@ -109,6 +110,18 @@ public final class SQLiteAsyncExecutor {
                     error.initCause(e);
                     throw error;
                 }
+            }
+        };
+        thread.start(transactional);
+        return thread;
+    }
+
+    public SQLiteThread execute(final SQLiteInsertSelection clause, ExecutionCallback<Integer> callback) {
+        SQLiteThread<Integer> thread = new SQLiteThread<Integer>(this, clause, callback) {
+
+            @Override
+            protected Integer onExecute() {
+                return clause.execute();
             }
         };
         thread.start(transactional);


### PR DESCRIPTION
## Summary
- add a `SQLiteInsertSelection` clause builder that reuses a source `SQLiteSelect`, supports value and expression overrides, and executes insert-select statements
- expose the builder via `SQLite.SQL.insertSelection`, extend async execution to handle the new clause, and document the API in the README
- cover the feature with an instrumentation test that copies rows while generating a random UUID, and configure androidTest dependencies

## Testing
- `./gradlew test` *(fails: Gradle 2.14.1 cannot run on the available JDK versions; it expects Java 8 while only 11+/21 are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c964ab3483288db34afcce0d792f