### PR TITLE
Quote SQL string literals in generated statements

### DIFF
--- a/src/istat/android/data/access/sqlite/SQLite.java
+++ b/src/istat/android/data/access/sqlite/SQLite.java
@@ -657,9 +657,16 @@ public final class SQLite {
             select.distinct = distinct;
             if (!TextUtils.isEmpty(whereClause)) {
                 select.whereClause = new StringBuilder(whereClause);
-                select.whereParams = Arrays.asList(whereParams);
+                if (whereParams != null) {
+                    select.whereParams = new ArrayList<String>(Arrays.asList(whereParams));
+                    select.whereParamValues = new ArrayList<Object>(select.whereParams);
+                } else {
+                    select.whereParams = new ArrayList<String>();
+                    select.whereParamValues = new ArrayList<Object>();
+                }
             } else {
-                select.whereParams = new ArrayList();
+                select.whereParams = new ArrayList<String>();
+                select.whereParamValues = new ArrayList<Object>();
             }
             select.limit = limit;
             select.orderBy = orderBy;
@@ -692,7 +699,13 @@ public final class SQLite {
             SQLiteUpdate.Updater update = update(classTable).updater;
             update.model.fillFromContentValues(contentValues);
             update.whereClause = new StringBuilder(whereClause);
-            update.whereParams = whereParams != null ? Arrays.asList(whereParams) : new ArrayList<String>();
+            if (whereParams != null) {
+                update.whereParams = new ArrayList<String>(Arrays.asList(whereParams));
+                update.whereParamValues = new ArrayList<Object>(update.whereParams);
+            } else {
+                update.whereParams = new ArrayList<String>();
+                update.whereParamValues = new ArrayList<Object>();
+            }
             update.limit = limit;
             update.having = new StringBuilder(having);
             return update.execute();

--- a/src/istat/android/data/access/sqlite/SQLiteClause.java
+++ b/src/istat/android/data/access/sqlite/SQLiteClause.java
@@ -1,6 +1,7 @@
 package istat.android.data.access.sqlite;
 
 import android.database.Cursor;
+import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
 import android.text.TextUtils;
 
@@ -16,6 +17,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -27,7 +29,9 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
     // protected SQLiteDatabase db;
     protected StringBuilder whereClause = null;
     protected List<String> whereParams = new ArrayList<String>();
+    protected List<Object> whereParamValues = new ArrayList<Object>();
     List<String> havingWhereParams = new ArrayList<String>();
+    List<Object> havingWhereParamValues = new ArrayList<Object>();
     protected String orderBy = null;
     protected String groupBy = null;
     protected StringBuilder having = null;
@@ -54,7 +58,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         if (having == null) {
             return null;
         }
-        String out = compute(this.having.toString(), havingWhereParams);
+        String out = compute(this.having.toString(), havingWhereParams, havingWhereParamValues);
         return out;
     }
 
@@ -235,7 +239,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
             whereClause = new StringBuilder(buildRealColumnName(column));
         } else
             whereClause.append(" AND " + buildRealColumnName(column));
-        return new ClauseBuilder(this.whereClause, this.whereParams, TYPE_CLAUSE_AND);
+        return new ClauseBuilder(this.whereClause, this.whereParams, this.whereParamValues, TYPE_CLAUSE_AND);
     }
 
     public ClauseBuilder or(String column) {
@@ -243,7 +247,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
             whereClause = new StringBuilder(buildRealColumnName(column));
         else
             whereClause.append(" OR " + buildRealColumnName(column));
-        return new ClauseBuilder(this.whereClause, this.whereParams, TYPE_CLAUSE_OR);
+        return new ClauseBuilder(this.whereClause, this.whereParams, this.whereParamValues, TYPE_CLAUSE_OR);
     }
 
     public ClauseBuilder and(String column) {
@@ -251,7 +255,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
             whereClause = new StringBuilder(buildRealColumnName(column));
         else
             whereClause.append(" AND " + buildRealColumnName(column));
-        return new ClauseBuilder(this.whereClause, this.whereParams, TYPE_CLAUSE_AND);
+        return new ClauseBuilder(this.whereClause, this.whereParams, this.whereParamValues, TYPE_CLAUSE_AND);
     }
 
     @SuppressWarnings("unchecked")
@@ -259,9 +263,11 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         if (whereClause == null) {
             this.whereClause = close.whereClause;
             this.whereParams = close.whereParams;
+            this.whereParamValues = close.whereParamValues;
         } else {
             this.whereClause.append(" AND " + close.whereClause);
             this.whereParams.addAll(close.whereParams);
+            this.whereParamValues.addAll(close.whereParamValues);
         }
         return (Clause) this;
     }
@@ -280,6 +286,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         this.whereClause.append(close.whereClause
                 + ")");
         this.whereParams.addAll(close.whereParams);
+        this.whereParamValues.addAll(close.whereParamValues);
         return (Clause) this;
     }
 
@@ -291,6 +298,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         this.whereClause.append(close.whereClause
                 + ")");
         this.whereParams.addAll(close.whereParams);
+        this.whereParamValues.addAll(close.whereParamValues);
         return (Clause) this;
     }
 
@@ -344,11 +352,13 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         int type = 0;
         StringBuilder whereClause;
         List<String> whereParams;
+        List<Object> whereParamValues;
 
-        ClauseBuilder(StringBuilder whereClause, List<String> whereParams, int type) {
+        ClauseBuilder(StringBuilder whereClause, List<String> whereParams, List<Object> whereParamValues, int type) {
             this.type = type;
             this.whereClause = whereClause;
             this.whereParams = whereParams;
+            this.whereParamValues = whereParamValues;
         }
 
         public Clause isNULL() {
@@ -476,24 +486,28 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         @SuppressWarnings("unchecked")
         public Clause equalTo(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" = (" + value + ") ");
             return (Clause) SQLiteClause.this;
         }
 
         public Clause notEqualTo(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" != (" + value + ") ");
             return (Clause) SQLiteClause.this;
         }
 
         public Clause notIn(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" NOT IN (" + value.getSql() + ") ");
             return (Clause) SQLiteClause.this;
         }
 
         public Clause in(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" IN (" + value.getSql() + ") ");
             return (Clause) SQLiteClause.this;
         }
@@ -509,6 +523,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         @SuppressWarnings("unchecked")
         public Clause greatThan(SQLiteSelect value, boolean acceptEqual) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" >" + (acceptEqual ? "=" : "") + " (" + value.getSql() + ") ");
             return (Clause) SQLiteClause.this;
         }
@@ -516,6 +531,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         @SuppressWarnings("unchecked")
         public Clause lessThan(SQLiteSelect value, boolean acceptEqual) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" <" + (acceptEqual ? "=" : "") + " (" + value.getSql() + ") ");
             return (Clause) SQLiteClause.this;
         }
@@ -523,6 +539,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         @SuppressWarnings("unchecked")
         public Clause like(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" like (" + value.getSql() + ")");
             return (Clause) SQLiteClause.this;
         }
@@ -530,6 +547,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         @SuppressWarnings("unchecked")
         public Clause notLike(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" NOT like (" + value.getSql() + ")");
             return (Clause) SQLiteClause.this;
         }
@@ -537,6 +555,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         @SuppressWarnings("unchecked")
         public Clause between(SQLiteSelect value, SQLiteSelect value2) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" BETWEEN (" + value.getSql() + ") AND (" + value2.getSql() + ")");
             return (Clause) SQLiteClause.this;
         }
@@ -544,6 +563,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         @SuppressWarnings("unchecked")
         public Clause notBetween(SQLiteSelect value, SQLiteSelect value2) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" BETWEEN (" + value.getSql() + ") AND (" + value2.getSql() + ")");
             return (Clause) SQLiteClause.this;
         }
@@ -551,6 +571,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
 
         private void prepare(Object value) {
             whereParams.add(value + "");
+            whereParamValues.add(value);
             switch (type) {
                 case TYPE_CLAUSE_AND:
 
@@ -600,6 +621,7 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
 
         private void prepare(Object value) {
             whereParams.add(value + "");
+            havingWhereParamValues.add(value);
             switch (type) {
                 case TYPE_CLAUSE_AND:
 
@@ -646,19 +668,65 @@ abstract class SQLiteClause<Clause extends SQLiteClause<?>> implements SQLiteCla
         }
     }
 
-    String compute(String out, List<String> whereParams) {
+    String compute(String out, List<String> whereParams, List<Object> rawParams) {
         String[] splits = out.split("\\?");
-        String sql = "";
-        for (int i = 0; i < (!out.endsWith("?") ? splits.length - 1
-                : splits.length); i++) {
-            sql += splits[i];
-            if (i < whereParams.size())
-                sql += whereParams.get(i);
+        StringBuilder sql = new StringBuilder();
+        int loopBound = !out.endsWith("?") ? splits.length - 1 : splits.length;
+        for (int i = 0; i < loopBound; i++) {
+            sql.append(splits[i]);
+            if (i < whereParams.size()) {
+                sql.append(buildLiteral(whereParams.get(i), rawParams, i));
+            }
         }
         if (!out.endsWith("?")) {
-            sql += splits[splits.length - 1];
+            sql.append(splits[splits.length - 1]);
         }
-        return sql;
+        return sql.toString();
+    }
+
+    private String buildLiteral(String value, List<Object> rawParams, int index) {
+        boolean hasRawValue = rawParams != null && index < rawParams.size();
+        if (hasRawValue) {
+            Object rawValue = rawParams.get(index);
+            if (rawValue == null) {
+                return "NULL";
+            }
+            if (rawValue instanceof Number) {
+                return String.valueOf(rawValue);
+            }
+            if (rawValue instanceof byte[]) {
+                return toHexBlob((byte[]) rawValue);
+            }
+            return DatabaseUtils.sqlEscapeString(String.valueOf(rawValue));
+        }
+        if (value == null) {
+            return "NULL";
+        }
+        if (isNumeric(value)) {
+            return value;
+        }
+        return DatabaseUtils.sqlEscapeString(value);
+    }
+
+    private String toHexBlob(byte[] blob) {
+        StringBuilder builder = new StringBuilder("X'");
+        for (byte b : blob) {
+            builder.append(String.format(Locale.US, "%02X", b));
+        }
+        builder.append("'");
+        return builder.toString();
+    }
+
+    private boolean isNumeric(String value) {
+        if (TextUtils.isEmpty(value)) {
+            return false;
+        }
+        try {
+            Double.parseDouble(value);
+            return true;
+        } catch (NumberFormatException ignored) {
+            return false;
+        }
     }
 
     @Override

--- a/src/istat/android/data/access/sqlite/SQLiteDelete.java
+++ b/src/istat/android/data/access/sqlite/SQLiteDelete.java
@@ -55,20 +55,20 @@ public final class SQLiteDelete extends SQLiteClause<SQLiteDelete> {
     @Override
     public String getStatement() {
         String out = "DELETE FROM " + table;
+        String whereClause = getWhereClause();
+        String queryEnding = (TextUtils.isEmpty(orderBy) ? "" : " ORDER BY " + orderBy)
+                + (TextUtils.isEmpty(orderBy) ? "" : " LIMIT " + limit);
+        if (!TextUtils.isEmpty(queryEnding)) {
+            if (whereClause == null) {
+                whereClause = queryEnding;
+            } else {
+                whereClause += queryEnding;
+            }
+        }
         if (!TextUtils.isEmpty(whereClause)) {
-            out += " WHERE '" + whereClause.toString().trim() + "'";
+            out += " WHERE " + whereClause.trim();
         }
-        String[] splits = out.split("\\?");
-        String sql = "";
-        for (int i = 0; i < (!out.endsWith("?") ? splits.length - 1
-                : splits.length); i++) {
-            sql += splits[i];
-            sql += "'" + whereParams.get(i) + "'";
-        }
-        if (!out.endsWith("?")) {
-            sql += splits[splits.length - 1];
-        }
-        return sql;
+        return compute(out, this.whereParams, this.whereParamValues);
     }
 
     public SQLiteDelete.SQLiteDeleteLimit limit(int limit) {

--- a/src/istat/android/data/access/sqlite/SQLiteSelect.java
+++ b/src/istat/android/data/access/sqlite/SQLiteSelect.java
@@ -370,7 +370,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         if (!TextUtils.isEmpty(whereClause)) {
             out += " WHERE " + whereClause.trim();
         }
-        String sql = compute(out, this.whereParams);
+        String sql = compute(out, this.whereParams, this.whereParamValues);
         if (!TextUtils.isEmpty(groupBy)) {
             sql += " GROUP BY " + groupBy;
         }
@@ -491,6 +491,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         @SuppressWarnings("unchecked")
         public SQLiteJoinSelect equalTo(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" = (" + value + ") ");
             return selectClause;
         }
@@ -498,18 +499,21 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         @SuppressWarnings("unchecked")
         public SQLiteJoinSelect notEqualTo(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" = (" + value + ") ");
             return selectClause;
         }
 
         public SQLiteJoinSelect in(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" IN (" + value.getSql() + ") ");
             return selectClause;
         }
 
         public SQLiteJoinSelect notIn(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" NOT IN (" + value.getSql() + ") ");
             return selectClause;
         }
@@ -525,6 +529,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         @SuppressWarnings("unchecked")
         public SQLiteJoinSelect greatThan(SQLiteSelect value, boolean acceptEqual) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" >" + (acceptEqual ? "=" : "") + " (" + value.getSql() + ") ");
             return selectClause;
         }
@@ -532,6 +537,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         @SuppressWarnings("unchecked")
         public SQLiteJoinSelect lessThan(SQLiteSelect value, boolean acceptEqual) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" <" + (acceptEqual ? "=" : "") + " (" + value.getSql() + ") ");
             return selectClause;
         }
@@ -539,6 +545,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         @SuppressWarnings("unchecked")
         public SQLiteJoinSelect like(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" like (" + value.getSql() + ")");
             return selectClause;
         }
@@ -546,6 +553,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         @SuppressWarnings("unchecked")
         public SQLiteJoinSelect notLike(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
+            whereParamValues.addAll(value.whereParamValues);
             whereClause.append(" NOT like (" + value.getSql() + ")");
             return selectClause;
         }
@@ -554,6 +562,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
 
         private void prepare(Object value) {
             whereParams.add(value + "");
+            whereParamValues.add(value);
             switch (type) {
                 case TYPE_CLAUSE_AND:
 
@@ -743,6 +752,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
             super(db, clazz);
             this.whereClause = SQLiteSelect.this.whereClause;
             this.whereParams = SQLiteSelect.this.whereParams;
+            this.whereParamValues = SQLiteSelect.this.whereParamValues;
             this.selectionTable = SQLiteSelect.this.selectionTable;
             this.table = SQLiteSelect.this.table;
             this.tableAliases = SQLiteSelect.this.tableAliases;
@@ -801,7 +811,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
                 this.having = new StringBuilder(buildRealColumnName(table, having));
             else
                 this.having.append(" " + or_and + " " + buildRealColumnName(table, having));
-            ClauseBuilder builder = new ClauseBuilder(this.having, havingWhereParams, TYPE_CLAUSE_AND_HAVING);
+            ClauseBuilder builder = new ClauseBuilder(this.having, havingWhereParams, havingWhereParamValues, TYPE_CLAUSE_AND_HAVING);
             return builder;
         }
 
@@ -820,7 +830,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
                 this.having = new StringBuilder(value);
             else
                 this.having.append(" " + or_and + " " + value);
-            ClauseBuilder builder = new ClauseBuilder(this.having, havingWhereParams, TYPE_CLAUSE_AND_HAVING);
+            ClauseBuilder builder = new ClauseBuilder(this.having, havingWhereParams, havingWhereParamValues, TYPE_CLAUSE_AND_HAVING);
             return builder;
         }
 
@@ -976,7 +986,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
             this.having = new StringBuilder(buildRealColumnName(having));
         else
             this.having.append(" " + or_and + " " + buildRealColumnName(having));
-        ClauseBuilder builder = new ClauseBuilder(this.having, havingWhereParams, TYPE_CLAUSE_AND_HAVING);
+        ClauseBuilder builder = new ClauseBuilder(this.having, havingWhereParams, havingWhereParamValues, TYPE_CLAUSE_AND_HAVING);
         return builder;
     }
 
@@ -986,7 +996,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
             this.having = new StringBuilder(value);
         else
             this.having.append(" " + or_and + " " + value);
-        ClauseBuilder builder = new ClauseBuilder(this.having, havingWhereParams, TYPE_CLAUSE_AND_HAVING);
+        ClauseBuilder builder = new ClauseBuilder(this.having, havingWhereParams, havingWhereParamValues, TYPE_CLAUSE_AND_HAVING);
         return builder;
     }
 

--- a/src/istat/android/data/access/sqlite/SQLiteUpdate.java
+++ b/src/istat/android/data/access/sqlite/SQLiteUpdate.java
@@ -135,7 +135,7 @@ public final class SQLiteUpdate implements SQLiteClauseAble {
             if (!TextUtils.isEmpty(whereClause)) {
                 out += " WHERE " + whereClause.trim();
             }
-            String sql = compute(out, this.whereParams);
+            String sql = compute(out, this.whereParams, this.whereParamValues);
             if (!TextUtils.isEmpty(limit)) {
                 sql += " LIMIT " + limit;
             }

--- a/src/test/java/istat/android/data/access/sqlite/SQLiteSelectTest.java
+++ b/src/test/java/istat/android/data/access/sqlite/SQLiteSelectTest.java
@@ -53,4 +53,16 @@ public class SQLiteSelectTest {
         String innerStatement = innerJoin.getStatement();
         assertTrue(innerStatement.contains("ON (child_table.parent_id=parent_table.id)"));
     }
+
+    @Test
+    public void whereEqualToShouldQuoteStringValuesInStatements() {
+        SQLite.SQL sql = new SQLite.SQL(null);
+        SQLiteSelect select = sql.select(DummyEntity.class);
+
+        select.where("name").equalTo("Bob");
+
+        String statement = select.getStatement();
+
+        assertTrue("Statement should contain the quoted literal", statement.contains("WHERE dummy_table.name = 'Bob'"));
+    }
 }


### PR DESCRIPTION
## Summary
- Track original clause parameter values so `compute()` can escape text literals with `DatabaseUtils`
- Update select, delete, and update statements to reuse the enhanced substitution logic
- Add a unit test that verifies `where().equalTo("Bob")` produces a quoted literal in the statement output

## Testing
- ./gradlew test *(fails: Plugin with id 'com.android.library' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d2cc575b788328a6d46fbde129c327