### PR TITLE
Fix projection handling in SQLiteSelect getStatement

### DIFF
--- a/src/istat/android/data/access/sqlite/SQLiteSelect.java
+++ b/src/istat/android/data/access/sqlite/SQLiteSelect.java
@@ -304,14 +304,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
 //    }
 
     final String getSql() {
-        String columns = "";//"*";
-        for (int i = 0; i < this.columns.length; i++) {
-            columns += this.columns[i];
-            if (i < this.columns.length - 1) {
-                columns += ",";
-            }
-        }
-        String out = buildSelectClause(columns);
+        String out = buildSelectClause(buildColumnExpression());
         String whereClause = getWhereClause();
         String having = getHaving();
         String orderBy = getOrderBy();
@@ -346,22 +339,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
 
     @Override
     public final String getStatement() {
-        String columnParam = "*";
-        try {
-            SQLiteModel entity = SQLiteModel.fromClass(clazz);
-            if (entity.getColumns().length != this.columns.length) {
-                columnParam = "";
-                for (int i = 0; i < this.columns.length; i++) {
-                    columnParam += this.columns[i];
-                    if (i < this.columns.length - 1) {
-                        columnParam += ",";
-                    }
-                }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        String out = buildSelectClause(columnParam);
+        String out = buildSelectClause(buildColumnExpression());
         String whereClause = getWhereClause();
         String having = getHaving();
         String orderBy = getOrderBy();
@@ -384,6 +362,20 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
             sql += " LIMIT " + limit;
         }
         return sql;
+    }
+
+    private String buildColumnExpression() {
+        if (this.columns == null || this.columns.length == 0) {
+            return "*";
+        }
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < this.columns.length; i++) {
+            if (i > 0) {
+                builder.append(",");
+            }
+            builder.append(this.columns[i]);
+        }
+        return builder.toString();
     }
 
     private String buildSelectClause(String columnExpression) {

--- a/src/test/java/istat/android/data/access/sqlite/SQLiteSelectTest.java
+++ b/src/test/java/istat/android/data/access/sqlite/SQLiteSelectTest.java
@@ -65,4 +65,16 @@ public class SQLiteSelectTest {
 
         assertTrue("Statement should contain the quoted literal", statement.contains("WHERE dummy_table.name = 'Bob'"));
     }
+
+    @Test
+    public void getStatementShouldUseProjectionWithAliases() {
+        SQLite.SQL sql = new SQLite.SQL(null);
+        String[] projection = new String[]{"COUNT(dummy_table.id) AS size", "dummy_table.name"};
+        SQLiteSelect select = sql.select(projection, DummyEntity.class);
+
+        String statement = select.getStatement();
+
+        assertTrue("Projection should include the COUNT alias", statement.startsWith(
+                "SELECT COUNT(dummy_table.id) AS size,dummy_table.name FROM dummy_table"));
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `SQLiteSelect.getStatement()` always rebuilds the column projection from the configured columns, mirroring `getSql()`
- refactor projection formatting into a shared helper used by both statement builders
- add a unit test covering alias and aggregate projections to confirm `getStatement()` preserves them

## Testing
- `./gradlew test` *(fails: Gradle 2.14.1 cannot determine Java version from available JDKs such as 21.0.2 or 17.0.2)*

------
https://chatgpt.com/codex/tasks/task_e_68d2de62e3148328bc4bc63200a51f33