### PR TITLE
Fix insert selection statement literals

### DIFF
--- a/src/istat/android/data/access/sqlite/SQLiteInsertSelection.java
+++ b/src/istat/android/data/access/sqlite/SQLiteInsertSelection.java
@@ -38,8 +38,10 @@ public final class SQLiteInsertSelection extends SQLiteClause<SQLiteInsertSelect
         }
         this.whereClause = selection.whereClause != null ? new StringBuilder(selection.whereClause.toString()) : null;
         this.whereParams = new ArrayList<String>(selection.whereParams);
+        this.whereParamValues = new ArrayList<Object>(selection.whereParamValues);
         this.having = selection.having != null ? new StringBuilder(selection.having.toString()) : null;
         this.havingWhereParams = new ArrayList<String>(selection.havingWhereParams);
+        this.havingWhereParamValues = new ArrayList<Object>(selection.havingWhereParamValues);
         this.orderBy = selection.orderBy;
         this.groupBy = selection.groupBy;
         this.limit = selection.limit;
@@ -131,11 +133,12 @@ public final class SQLiteInsertSelection extends SQLiteClause<SQLiteInsertSelect
     @Override
     public String getStatement() {
         String sqlStatement = buildInsertSelectSql();
-        List<String> bindArgs = new ArrayList<String>();
-        for (Object arg : buildBindArgs()) {
-            bindArgs.add(arg == null ? "null" : String.valueOf(arg));
+        List<Object> rawArgs = buildBindArgs();
+        List<String> bindArgs = new ArrayList<String>(rawArgs.size());
+        for (Object arg : rawArgs) {
+            bindArgs.add(arg == null ? null : String.valueOf(arg));
         }
-        return compute(sqlStatement, bindArgs);
+        return compute(sqlStatement, bindArgs, rawArgs);
     }
 
     @Override
@@ -209,8 +212,8 @@ public final class SQLiteInsertSelection extends SQLiteClause<SQLiteInsertSelect
                 args.add(projection.bindArg);
             }
         }
-        args.addAll(whereParams);
-        args.addAll(havingWhereParams);
+        args.addAll(whereParamValues);
+        args.addAll(havingWhereParamValues);
         return args;
     }
 


### PR DESCRIPTION
## Summary
- propagate raw parameter values from the source selection when building insert-from-select clauses
- build both string and raw argument lists for `compute` so generated statements escape literals correctly

## Testing
- `./gradlew test` *(fails: Gradle wrapper does not support Java 21)*

------
https://chatgpt.com/codex/tasks/task_e_68d2df857ef48328a657b0639a62e382