### PR TITLE
Fix join notEqualTo SQL and add inequality test

### DIFF
--- a/src/istat/android/data/access/sqlite/SQLiteSelect.java
+++ b/src/istat/android/data/access/sqlite/SQLiteSelect.java
@@ -414,7 +414,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         @SuppressWarnings("unchecked")
         public SQLiteJoinSelect notEqualTo(Object value) {
             prepare(value);
-            whereClause.append(" = ? ");
+            whereClause.append(" != ? ");
             return selectClause;
         }
 
@@ -494,7 +494,7 @@ public class SQLiteSelect extends SQLiteClause<SQLiteSelect> implements Selectio
         public SQLiteJoinSelect notEqualTo(SQLiteSelect value) {
             whereParams.addAll(value.whereParams);
             whereParamValues.addAll(value.whereParamValues);
-            whereClause.append(" = (" + value + ") ");
+            whereClause.append(" != (" + value.getSql() + ") ");
             return selectClause;
         }
 

--- a/src/test/java/istat/android/data/access/sqlite/SQLiteSelectTest.java
+++ b/src/test/java/istat/android/data/access/sqlite/SQLiteSelectTest.java
@@ -55,6 +55,21 @@ public class SQLiteSelectTest {
     }
 
     @Test
+    public void joinWhereNotEqualToShouldUseInequalityOperator() {
+        SQLite.SQL sql = new SQLite.SQL(null);
+
+        SQLiteSelect select = sql.select(ChildEntity.class);
+        select.innerJoin(ParentEntity.class)
+                .where(ParentEntity.class, "id")
+                .notEqualTo(5);
+
+        String statement = select.getStatement();
+
+        assertTrue(statement.contains("parent_table.id != 5"));
+        assertTrue("Join clause should remain intact", statement.contains("ON (child_table.parent_id=parent_table.id)"));
+    }
+
+    @Test
     public void whereEqualToShouldQuoteStringValuesInStatements() {
         SQLite.SQL sql = new SQLite.SQL(null);
         SQLiteSelect select = sql.select(DummyEntity.class);


### PR DESCRIPTION
## Summary
- ensure ClauseJoinSelectBuilder.notEqualTo(Object) appends the inequality operator
- update ClauseJoinSelectBuilder.notEqualTo(SQLiteSelect) to emit subqueries with the same operator
- add a join unit test that covers notEqualTo and asserts the generated SQL keeps the join filter

## Testing
- JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 ./gradlew test *(fails: Plugin with id 'com.android.library' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d31151dfdc83289a724a7307c91bbf